### PR TITLE
Correctly draw chunk borders

### DIFF
--- a/src/main/java/net/xolt/freecam/mixins/ChunkBorderDebugRendererMixin.java
+++ b/src/main/java/net/xolt/freecam/mixins/ChunkBorderDebugRendererMixin.java
@@ -1,0 +1,25 @@
+package net.xolt.freecam.mixins;
+
+import net.minecraft.client.render.debug.ChunkBorderDebugRenderer;
+import net.minecraft.entity.Entity;
+import net.xolt.freecam.Freecam;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import static net.xolt.freecam.Freecam.MC;
+
+@Mixin(ChunkBorderDebugRenderer.class)
+public class ChunkBorderDebugRendererMixin {
+    
+    @ModifyVariable(method = "render", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/render/Camera;getFocusedEntity()Lnet/minecraft/entity/Entity;"))
+    private Entity getFocusedEntity(Entity in) {
+        if (Freecam.isEnabled()) {
+            // When ShowPlayer is enabled, FreeCamera.getFocusedEntity returns MC.player.
+            // When rendering chunk borders, we actually want the camera's position not the player's.
+            return MC.getCameraEntity();
+        }
+        return in;
+    }
+
+}

--- a/src/main/resources/freecam.mixins.json
+++ b/src/main/resources/freecam.mixins.json
@@ -5,6 +5,7 @@
   "client": [
     "BlockEntityRendererMixin",
     "CameraMixin",
+    "ChunkBorderDebugRendererMixin",
     "ClientConnectionMixin",
     "ClientPlayerEntityMixin",
     "ClientPlayerInteractionManagerMixin",


### PR DESCRIPTION
`ChunkBorderDebugRenderer` (AKA `F3`+`G`) uses the camera's focused entity (`MC.gameRenderer.getCamera().getFocusedEntity()`) in order to figure out which chunk to highlight in yellow and which should just be in red.

`CameraMixin` injects into `getFocusedEntity()` however in order to make the "Show Player" option function... This means the yellow chunk is always the chunk with the player in it, not the one with the camera in it, when "Show Player" is enabled.

![2022-05-10_21 35 27](https://user-images.githubusercontent.com/5046562/167718439-daa6c235-4911-4ae9-bbef-55624c10f02b.png)

We can fix this by overriding the override... When `ChunkBorderDebugRenderer.render` invokes `Camera.getFocusedEntity` it assigns the result to a local variable, so we can use mixin's `ModifyVariable` feature to override the override back to the camera.

```java
@ModifyVariable(method = "render", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/render/Camera;getFocusedEntity()Lnet/minecraft/entity/Entity;"))
private Entity getFocusedEntity(Entity in) {
    if (Freecam.isEnabled()) {
        return MC.getCameraEntity();
    }
    return in;
}
```

_(For some reason the [Minecraft Dev intellij plugin](https://github.com/minecraft-dev/MinecraftDev) reports the method signature as incorrect, but that must be a bug in the plugin. It compiles, works correctly with Mixin and matches the docs...)_

![2022-05-10_21 33 59](https://user-images.githubusercontent.com/5046562/167719381-cb9b4bba-3703-4cbd-91a5-623f446f9c3f.png)

The perfectionist in me would like to find the _one place_ in the vanilla code we actually need to modify in order for "Show Player" to work, `WorldRenderer.render` would probably be a starting point. This line looks particularly suspicious:

```java
do { /* ... */
    do { /* ... */ } while(entity == camera.getFocusedEntity() && !camera.isThirdPerson() && (!(camera.getFocusedEntity() instanceof LivingEntity) || !((LivingEntity)camera.getFocusedEntity()).isSleeping()));
} while(entity instanceof ClientPlayerEntity && camera.getFocusedEntity() != entity); /* ... */
```

That said, I don't really want to spend forever digging through the render code looking for specific places we need to change values when what we have now works fine.