### PR TITLE
"Initial Perspective" config option

### DIFF
--- a/src/main/java/net/xolt/freecam/config/ModConfig.java
+++ b/src/main/java/net/xolt/freecam/config/ModConfig.java
@@ -7,6 +7,7 @@ import me.shedaniel.autoconfig.annotation.ConfigEntry;
 import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Comment;
 import me.shedaniel.clothconfig2.gui.entries.SelectionListEntry;
+import org.jetbrains.annotations.NotNull;
 
 @Config(name = "freecam")
 public class ModConfig implements ConfigData {
@@ -38,6 +39,10 @@ public class ModConfig implements ConfigData {
     @Comment("Whether taking damage disables freecam.")
     public boolean disableOnDamage = true;
 
+    @Comment("The initial perspective of the camera.")
+    @ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.BUTTON)
+    public Perspective perspective = Perspective.THIRD_PERSON;
+
     @Comment("Whether your player is shown in your original position.")
     public boolean showPlayer = true;
 
@@ -57,7 +62,24 @@ public class ModConfig implements ConfigData {
             this.name = name;
         }
 
-        public String getKey() {
+        public @NotNull String getKey() {
+            return name;
+        }
+    }
+
+    public enum Perspective implements SelectionListEntry.Translatable {
+        FIRST_PERSON("First Person"),
+        THIRD_PERSON("Third Person"),
+        THIRD_PERSON_MIRROR("Mirror"),
+        INSIDE("Inside");
+
+        private final String name;
+
+        Perspective(String name) {
+            this.name = name;
+        }
+
+        public @NotNull String getKey() {
             return name;
         }
     }

--- a/src/main/java/net/xolt/freecam/util/FreeCamera.java
+++ b/src/main/java/net/xolt/freecam/util/FreeCamera.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.client.input.KeyboardInput;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityPose;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectInstance;
@@ -27,7 +28,7 @@ public class FreeCamera extends ClientPlayerEntity {
     public FreeCamera() {
         super(MC, MC.world, NETWORK_HANDLER, MC.player.getStatHandler(), MC.player.getRecipeBook(), false, false);
 
-        copyPositionAndRotation(MC.player);
+        copyPositionAndRotation(MC.player, ModConfig.INSTANCE.perspective);
         renderPitch = getPitch();
         renderYaw = getYaw();
         lastRenderPitch = renderPitch; // Prevents camera from rotating upon entering freecam.
@@ -88,5 +89,31 @@ public class FreeCamera extends ClientPlayerEntity {
         super.tickMovement();
         getAbilities().flying = true;
         onGround = false;
+    }
+
+    private void copyPositionAndRotation(Entity entity, ModConfig.Perspective perspective) {
+        // Copy the entity's position and rotation
+        PositionRotationUtil util = new PositionRotationUtil(entity);
+
+        // Mutate the position and rotation based on ModConfig
+        switch (perspective) {
+            case INSIDE:
+                // No-op
+                break;
+            case FIRST_PERSON:
+                // Move just in front of the player's eyes
+                util.moveForward(0.3);
+                break;
+            case THIRD_PERSON_MIRROR:
+                // Invert the rotation and fallthrough into the THIRD_PERSON case
+                util.mirrorRotation();
+            case THIRD_PERSON:
+                // Move back 4 blocks, as per F5 mode
+                util.moveForward(-4.0);
+                break;
+        }
+
+        // Apply the mutated position and rotation to the FreeCamera
+        util.applyPositionAndRotation(this);
     }
 }

--- a/src/main/java/net/xolt/freecam/util/PositionRotationUtil.java
+++ b/src/main/java/net/xolt/freecam/util/PositionRotationUtil.java
@@ -1,0 +1,133 @@
+package net.xolt.freecam.util;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Quaternion;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.Vec3f;
+
+public class PositionRotationUtil {
+
+    private final Vec3f verticalPlane = new Vec3f(0.0F, 1.0F, 0.0F);
+    private final Vec3f diagonalPlane = new Vec3f(1.0F, 0.0F, 0.0F);
+    private final Vec3f horizontalPlane = new Vec3f(0.0F, 0.0F, 1.0F);
+    private Vec3d position = Vec3d.ZERO;
+    private float pitch = 0;
+    private float yaw = 0;
+
+
+    public PositionRotationUtil(double x, double y, double z, float yaw, float pitch) {
+        setPosition(x, y, z);
+        setRotation(yaw, pitch);
+    }
+
+    public PositionRotationUtil(double x, double y, double z) {
+        this(x, y, z, 0, 0);
+    }
+
+    public PositionRotationUtil(float yaw, float pitch) {
+        this(0, 0, 0, yaw, pitch);
+    }
+
+    public PositionRotationUtil() {
+        this(0, 0, 0, 0, 0);
+    }
+
+    public PositionRotationUtil(Entity entity) {
+        this();
+        copyPositionAndRotation(entity);
+    }
+
+    public void copyPositionAndRotation(Entity entity) {
+        setPosition(entity.getX(), entity.getY(), entity.getZ());
+        setRotation(entity.getYaw(), entity.getPitch());
+    }
+
+    public void applyPositionAndRotation(Entity entity) {
+        entity.refreshPositionAndAngles(getX(), getY(), getZ(), getYaw(), getPitch());
+    }
+
+    // Move forward/backward relative to the current rotation
+    public void moveForward(double distance) {
+        move(distance, 0, 0);
+    }
+
+    // Move up/down relative to the current rotation
+    public void moveUp(double distance) {
+        move(0, distance, 0);
+    }
+
+    // Move right/left relative to the current rotation
+    public void moveRight(double distance) {
+        move(0, 0, distance);
+    }
+
+    // Move relative to current rotation
+    // From net.minecraft.client.render.Camera.moveBy
+    public void move(double fwd, double up, double right) {
+        double xShift = (double) horizontalPlane.getX() * fwd + (double) verticalPlane.getX() * up + (double) diagonalPlane.getX() * right;
+        double yShift = (double) horizontalPlane.getY() * fwd + (double) verticalPlane.getY() * up + (double) diagonalPlane.getY() * right;
+        double zShift = (double) horizontalPlane.getZ() * fwd + (double) verticalPlane.getZ() * up + (double) diagonalPlane.getZ() * right;
+        setPosition(getX() + xShift, getY() + yShift, getZ() + zShift);
+    }
+
+    public void setPosition(double x, double y, double z) {
+        position = new Vec3d(x, y, z);
+    }
+
+    // Invert the rotation so it is mirrored
+    // As-per net.minecraft.client.render.Camera.update
+    public void mirrorRotation() {
+        setRotation(yaw + 180.0F, -pitch);
+    }
+
+    // Set the rotation angles
+    // From net.minecraft.client.render.Camera.setRotation
+    public void setRotation(float yaw, float pitch) {
+        this.pitch = pitch;
+        this.yaw = yaw;
+
+        // If this was being run often, we'd want to store rotation in a
+        // final-field, to be more memory efficient.
+        Quaternion rotation = new Quaternion(0.0F, 0.0F, 0.0F, 1.0F);
+        rotation.hamiltonProduct(Vec3f.POSITIVE_Y.getDegreesQuaternion(-yaw));
+        rotation.hamiltonProduct(Vec3f.POSITIVE_X.getDegreesQuaternion(pitch));
+
+        horizontalPlane.set(0.0F, 0.0F, 1.0F);
+        horizontalPlane.rotate(rotation);
+
+        verticalPlane.set(0.0F, 1.0F, 0.0F);
+        verticalPlane.rotate(rotation);
+
+        diagonalPlane.set(1.0F, 0.0F, 0.0F);
+        diagonalPlane.rotate(rotation);
+    }
+
+    public double getX() {
+        return position.x;
+    }
+
+    public double getY() {
+        return position.y;
+    }
+
+    public double getZ() {
+        return position.z;
+    }
+
+    public float getYaw() {
+        return yaw;
+    }
+
+    public float getPitch() {
+        return pitch;
+    }
+
+    public Vec3d getPosition() {
+        return new Vec3d(getX(), getY(), getZ());
+    }
+
+    public BlockPos getBlockPos() {
+        return new BlockPos(getX(), getY(), getZ());
+    }
+}

--- a/src/main/resources/assets/freecam/lang/en_us.json
+++ b/src/main/resources/assets/freecam/lang/en_us.json
@@ -9,6 +9,7 @@
   "text.autoconfig.freecam.option.horizontalSpeed": "Horizontal Speed",
   "text.autoconfig.freecam.option.verticalSpeed": "Vertical Speed",
   "text.autoconfig.freecam.option.noclip": "NoClip",
+  "text.autoconfig.freecam.option.perspective": "Initial Perspective",
   "text.autoconfig.freecam.option.showPlayer": "Show Player",
   "text.autoconfig.freecam.option.showHand": "Show Hand",
   "text.autoconfig.freecam.option.disableOnDamage": "Disable on Damage",


### PR DESCRIPTION
As requested in #16, I've added an option to select from one of the following initial camera perspectives:

- "Inside" this option retains the current behavior.
- "First Person" this option shifts the camera 0.3 blocks forward, to be just in front of the player's eyes.
- "Third Person" this option replicates F5 mode, moving the camera 4 blocks behind the player.
- "Mirror" this option replicates mirrored F5 mode, moving the camera 4 blocks in front of the player and inverting the camera.

Default is set to "Third Person" as this felt the most intuitive option during testing, but let me know if you'd rather something different and I can amend the commit.

Most of the backed logic comes from `net.minecraft.client.render.Camera`, which has been cleaned up and ported into a new util class `PositionRotationUtil`. Let me know if there's anything you'd like named/formatted differently or if you'd rather a different approach be taken somewhere.

https://user-images.githubusercontent.com/5046562/168478005-f961f7cf-6e6d-4992-989c-ba0b08841c78.mov

https://user-images.githubusercontent.com/5046562/168478356-ba94f2ae-80a0-4438-ad72-8863f5fe83ac.mov

https://user-images.githubusercontent.com/5046562/168478145-3baa1d31-a1fe-4fe5-8b98-ffcb821383ab.mov

https://user-images.githubusercontent.com/5046562/168478222-a615f646-4123-45e7-ad21-6a2d8ad15df3.mov

https://user-images.githubusercontent.com/5046562/168478285-b20c59d7-8b34-40a6-a1bc-fbe08a73389b.mov

Fixes #16