### PR TITLE
Increase Gradle's memory to 2GB

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
+org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
 mc_version=1.19.3


### PR DESCRIPTION
I was unable to build on a fresh machine with only 1GB. Was getting out-of-memory errors while downloading dependencies from maven. Guessing at some point the dependencies went over 1GB without you noticing since you probably have them cached. ¯\\\_(ツ)\_/¯