### PR TITLE
Use the "swimming" pose in freecam to improve navigation without noClip

### DIFF
--- a/src/main/java/net/xolt/freecam/Freecam.java
+++ b/src/main/java/net/xolt/freecam/Freecam.java
@@ -167,7 +167,7 @@ public class Freecam implements ClientModInitializer {
 
     private static void onEnableFreecam() {
         onEnable();
-        freeCamera = new FreeCamera(-420);
+        freeCamera = new FreeCamera(-420, FreecamPosition.getSwimmingPosition(MC.player));
         freeCamera.spawn();
         MC.setCameraEntity(freeCamera);
 

--- a/src/main/java/net/xolt/freecam/mixins/CameraMixin.java
+++ b/src/main/java/net/xolt/freecam/mixins/CameraMixin.java
@@ -1,0 +1,31 @@
+package net.xolt.freecam.mixins;
+
+import net.minecraft.client.render.Camera;
+import net.minecraft.entity.Entity;
+import net.minecraft.world.BlockView;
+import net.xolt.freecam.util.FreeCamera;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Camera.class)
+public class CameraMixin {
+
+    @Shadow Entity focusedEntity;
+    @Shadow float lastCameraY;
+    @Shadow float cameraY;
+
+    // When toggling freecam, update the camera's eye height instantly without any transition.
+    @Inject(method = "update", at = @At("HEAD"))
+    public void onUpdate(BlockView area, Entity newFocusedEntity, boolean thirdPerson, boolean inverseView, float tickDelta, CallbackInfo ci) {
+        if (newFocusedEntity == null || this.focusedEntity == null || newFocusedEntity.equals(this.focusedEntity)) {
+            return;
+        }
+
+        if (newFocusedEntity instanceof FreeCamera || this.focusedEntity instanceof FreeCamera) {
+            this.lastCameraY = this.cameraY = newFocusedEntity.getStandingEyeHeight();
+        }
+    }
+}

--- a/src/main/java/net/xolt/freecam/util/FreeCamera.java
+++ b/src/main/java/net/xolt/freecam/util/FreeCamera.java
@@ -26,15 +26,15 @@ public class FreeCamera extends ClientPlayerEntity {
     };
 
     public FreeCamera(int id) {
-        this(id, new FreecamPosition(MC.player));
+        this(id, FreecamPosition.getSwimmingPosition(MC.player));
     }
 
     public FreeCamera(int id, FreecamPosition position) {
         super(MC, MC.world, NETWORK_HANDLER, MC.player.getStatHandler(), MC.player.getRecipeBook(), false, false);
 
         setId(id);
-        refreshPositionAndAngles(position.x, position.y, position.z, position.yaw, position.pitch);
         super.setPose(position.pose);
+        refreshPositionAndAngles(position.x, position.y, position.z, position.yaw, position.pitch);
         renderPitch = getPitch();
         renderYaw = getYaw();
         lastRenderPitch = renderPitch; // Prevents camera from rotating upon entering freecam.
@@ -105,9 +105,7 @@ public class FreeCamera extends ClientPlayerEntity {
     // Prevents pose from changing when clipping through blocks.
     @Override
     public void setPose(EntityPose pose) {
-        if (pose.equals(EntityPose.STANDING) || (pose.equals(EntityPose.CROUCHING) && !getPose().equals(EntityPose.STANDING))) {
-            super.setPose(pose);
-        }
+        super.setPose(EntityPose.SWIMMING);
     }
 
     @Override

--- a/src/main/java/net/xolt/freecam/util/FreecamPosition.java
+++ b/src/main/java/net/xolt/freecam/util/FreecamPosition.java
@@ -21,6 +21,18 @@ public class FreecamPosition {
         pose = entity.getPose();
     }
 
+    public static FreecamPosition getSwimmingPosition(Entity entity) {
+        FreecamPosition position = new FreecamPosition(entity);
+
+        // Set pose to swimming, adjusting y position so eye-height doesn't change
+        if (position.pose != EntityPose.SWIMMING) {
+            position.y += entity.getEyeHeight(position.pose) - entity.getEyeHeight(EntityPose.SWIMMING);
+            position.pose = EntityPose.SWIMMING;
+        }
+
+        return position;
+    }
+
     public ChunkPos getChunkPos() {
         return new ChunkPos((int) (x / 16), (int) (z / 16));
     }

--- a/src/main/resources/freecam.mixins.json
+++ b/src/main/resources/freecam.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.xolt.freecam.mixins",
   "compatibilityLevel": "JAVA_17",
   "client": [
+    "CameraMixin",
     "ClientConnectionMixin",
     "ClientPlayerEntityMixin",
     "ClientPlayerInteractionManagerMixin",


### PR DESCRIPTION
The "swimming" pose is normally used when the player is crawling through a one-block-high space. Or when the player activates the swimming hotkey in water. The swimming pose has the smallest player hitbox available in survival, so when `noClip` is disabled the swimming pose is required to get through one-block-high gaps and tunnels.

I figured there's probably zero reason to ever need the larger poses while in freecam, so I've made it so that the `FreeCamera` entity's pose is always set to "Swimming".

We _could_ make the Freecam pose a config option, but I feel like that would needlessly clutter the config menu for little benefit...

Because the eye-hight is matched up with the player's seamlessly, you cannot actually tell your pose has changed until you start moving around and colliding with surfaces.

The new `CameraMixin` fixes a minor issue I found where setting the pose and moving the camera-entity's y-position confused the camera and caused it to show the camera offset by the eye-height difference and slowly transition back to the correct position. The mixin just sets the camera y-position manually whenever the focused camera-entity toggles to or from a `FreeCamera` instance.

I originally noticed this issue when you [pointed out](https://github.com/hashalite/Freecam/pull/25#issuecomment-1127031104) the no-clip complications over on #25, because `FreeCamera` using the "standing" pose causes it to collide really easily with the floor the player is standing on.