### PR TITLE
Fix disableOnDamage false-positives

### DIFF
--- a/src/main/java/net/xolt/freecam/mixins/ClientPlayerEntityMixin.java
+++ b/src/main/java/net/xolt/freecam/mixins/ClientPlayerEntityMixin.java
@@ -2,7 +2,6 @@ package net.xolt.freecam.mixins;
 
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.xolt.freecam.Freecam;
-import net.xolt.freecam.config.ModConfig;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -18,14 +17,6 @@ public class ClientPlayerEntityMixin {
     private void onIsCamera(CallbackInfoReturnable<Boolean> cir) {
         if (Freecam.isEnabled() && this.equals(MC.player)) {
             cir.setReturnValue(true);
-        }
-    }
-
-    // Disables freecam upon receiving damage if disableOnDamage is enabled.
-    @Inject(method = "damage", at = @At("HEAD"))
-    private void onDamage(CallbackInfoReturnable<Boolean> cir) {
-        if (Freecam.isEnabled() && ModConfig.INSTANCE.disableOnDamage && this.equals(MC.player) && !MC.player.isCreative()) {
-            Freecam.setDisableNextTick(true);
         }
     }
 }

--- a/src/main/java/net/xolt/freecam/mixins/LivingEntityMixin.java
+++ b/src/main/java/net/xolt/freecam/mixins/LivingEntityMixin.java
@@ -4,18 +4,34 @@ import net.minecraft.entity.LivingEntity;
 import net.xolt.freecam.Freecam;
 import net.xolt.freecam.config.ModConfig;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static net.xolt.freecam.Freecam.MC;
+
 @Mixin(LivingEntity.class)
-public class LivingEntityMixin {
+public abstract class LivingEntityMixin {
+
+    @Shadow public abstract float getHealth();
 
     // Allows for the horizontal speed of creative flight to be configured separately from vertical speed.
     @Inject(method = "getMovementSpeed(F)F", at = @At("HEAD"), cancellable = true)
     private void onGetMovementSpeed(CallbackInfoReturnable<Float> cir) {
         if (Freecam.isEnabled() && ModConfig.INSTANCE.flightMode.equals(ModConfig.FlightMode.CREATIVE) && this.equals(Freecam.getFreeCamera())) {
             cir.setReturnValue((float) (ModConfig.INSTANCE.horizontalSpeed / 10) * (Freecam.getFreeCamera().isSprinting() ? 2 : 1));
+        }
+    }
+
+    // Disables freecam upon receiving damage if disableOnDamage is enabled.
+    @Inject(method = "setHealth", at = @At("HEAD"))
+    private void onSetHealth(float health, CallbackInfo ci) {
+        if (Freecam.isEnabled() && ModConfig.INSTANCE.disableOnDamage && this.equals(MC.player)) {
+            if (!MC.player.isCreative() && getHealth() > health) {
+                Freecam.setDisableNextTick(true);
+            }
         }
     }
 }


### PR DESCRIPTION
`ClientPlayerEntity.damage()` is often called even when the player's health isn't actually going to change. For example, fire damage while under the effect of Fire Resistance.

Instead, let's check `LivingEntity.setHealth()`, since this is where actual changes to the player's health are made.

disableOnDamage will still activate when damaged while health is regenerating on average. But to fix that we'd have to track health over time and only disable when we detect a lasting reduction in health... Not in the scope of this simple PR.

Fixes #63