### PR TITLE
Drop requirement on Architectury API

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -8,9 +8,6 @@ loom {
 
 dependencies {
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
-
-    modApi "dev.architectury:architectury:${rootProject.architectury_version}"
-
     modApi "me.shedaniel.cloth:cloth-config:${rootProject.cloth_version}"
 }
 

--- a/common/src/main/java/net/xolt/freecam/Freecam.java
+++ b/common/src/main/java/net/xolt/freecam/Freecam.java
@@ -6,7 +6,6 @@ import net.minecraft.client.input.Input;
 import net.minecraft.client.input.KeyboardInput;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.option.Perspective;
-import net.minecraft.client.util.InputUtil;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.ChunkPos;
 import net.xolt.freecam.config.ModConfig;
@@ -15,23 +14,13 @@ import net.xolt.freecam.util.FreecamPosition;
 import org.lwjgl.glfw.GLFW;
 
 import java.util.HashMap;
-import java.util.List;
+
+import static net.xolt.freecam.config.ModBindings.*;
 
 public class Freecam {
 
     public static final MinecraftClient MC = MinecraftClient.getInstance();
     public static final String MOD_ID = "freecam";
-
-    public static final KeyBinding KEY_TOGGLE;
-    public static final KeyBinding KEY_PLAYER_CONTROL;
-    public static final KeyBinding KEY_TRIPOD_RESET;
-    public static final KeyBinding KEY_CONFIG_GUI;
-    public static final List<KeyBinding> ALL_KEYS = List.of(
-            KEY_TOGGLE = new KeyBinding("key.freecam.toggle", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_F4, "category.freecam.freecam"),
-            KEY_PLAYER_CONTROL = new KeyBinding("key.freecam.playerControl", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN, "category.freecam.freecam"),
-            KEY_TRIPOD_RESET = new KeyBinding("key.freecam.tripodReset", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN, "category.freecam.freecam"),
-            KEY_CONFIG_GUI = new KeyBinding("key.freecam.configGui", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN, "category.freecam.freecam")
-    );
 
     private static boolean freecamEnabled = false;
     private static boolean tripodEnabled = false;

--- a/common/src/main/java/net/xolt/freecam/Freecam.java
+++ b/common/src/main/java/net/xolt/freecam/Freecam.java
@@ -1,7 +1,5 @@
 package net.xolt.freecam;
 
-import dev.architectury.event.events.client.ClientTickEvent;
-import dev.architectury.registry.client.keymappings.KeyMappingRegistry;
 import me.shedaniel.autoconfig.AutoConfig;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.input.Input;
@@ -17,21 +15,23 @@ import net.xolt.freecam.util.FreecamPosition;
 import org.lwjgl.glfw.GLFW;
 
 import java.util.HashMap;
-import java.util.stream.Stream;
+import java.util.List;
 
 public class Freecam {
 
     public static final MinecraftClient MC = MinecraftClient.getInstance();
     public static final String MOD_ID = "freecam";
 
-    public static final KeyBinding KEY_TOGGLE = new KeyBinding(
-                "key.freecam.toggle", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_F4, "category.freecam.freecam");
-    public static final KeyBinding KEY_PLAYER_CONTROL = new KeyBinding(
-                "key.freecam.playerControl", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN, "category.freecam.freecam");
-    public static final KeyBinding KEY_TRIPOD_RESET = new KeyBinding(
-                "key.freecam.tripodReset", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN, "category.freecam.freecam");
-    public static final KeyBinding KEY_CONFIG_GUI = new KeyBinding(
-                "key.freecam.configGui", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN, "category.freecam.freecam");
+    public static final KeyBinding KEY_TOGGLE;
+    public static final KeyBinding KEY_PLAYER_CONTROL;
+    public static final KeyBinding KEY_TRIPOD_RESET;
+    public static final KeyBinding KEY_CONFIG_GUI;
+    public static final List<KeyBinding> ALL_KEYS = List.of(
+            KEY_TOGGLE = new KeyBinding("key.freecam.toggle", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_F4, "category.freecam.freecam"),
+            KEY_PLAYER_CONTROL = new KeyBinding("key.freecam.playerControl", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN, "category.freecam.freecam"),
+            KEY_TRIPOD_RESET = new KeyBinding("key.freecam.tripodReset", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN, "category.freecam.freecam"),
+            KEY_CONFIG_GUI = new KeyBinding("key.freecam.configGui", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_UNKNOWN, "category.freecam.freecam")
+    );
 
     private static boolean freecamEnabled = false;
     private static boolean tripodEnabled = false;
@@ -43,13 +43,6 @@ public class Freecam {
     private static HashMap<Integer, FreecamPosition> nether_tripods = new HashMap<>();
     private static HashMap<Integer, FreecamPosition> end_tripods = new HashMap<>();
     private static Perspective rememberedF5 = null;
-
-    public static void init() {
-        ModConfig.init();
-        Stream.of(KEY_TOGGLE, KEY_PLAYER_CONTROL, KEY_TRIPOD_RESET, KEY_CONFIG_GUI).forEach(KeyMappingRegistry::register);
-        ClientTickEvent.CLIENT_PRE.register(Freecam::preTick);
-        ClientTickEvent.CLIENT_POST.register(Freecam::postTick);
-    }
 
     public static void preTick(MinecraftClient mc) {
         if (isEnabled()) {

--- a/common/src/main/java/net/xolt/freecam/Freecam.java
+++ b/common/src/main/java/net/xolt/freecam/Freecam.java
@@ -80,6 +80,13 @@ public class Freecam {
         });
     }
 
+    public static void onDisconnect() {
+        if (isEnabled()) {
+            toggle();
+        }
+        clearTripods();
+    }
+
     public static void toggle() {
         if (tripodEnabled) {
             toggleTripod(activeTripod);

--- a/common/src/main/java/net/xolt/freecam/Freecam.java
+++ b/common/src/main/java/net/xolt/freecam/Freecam.java
@@ -51,7 +51,7 @@ public class Freecam {
         ClientTickEvent.CLIENT_POST.register(Freecam::postTick);
     }
 
-    private static void preTick(MinecraftClient mc) {
+    public static void preTick(MinecraftClient mc) {
         if (isEnabled()) {
             // Disable if the previous tick asked us to
             if (disableNextTick()) {
@@ -70,7 +70,7 @@ public class Freecam {
         }
     }
 
-    private static void postTick(MinecraftClient mc) {
+    public static void postTick(MinecraftClient mc) {
         if (KEY_TRIPOD_RESET.isPressed()) {
             for (KeyBinding hotbarKey : mc.options.hotbarKeys) {
                 while (hotbarKey.wasPressed()) {

--- a/common/src/main/java/net/xolt/freecam/config/ModBindings.java
+++ b/common/src/main/java/net/xolt/freecam/config/ModBindings.java
@@ -1,0 +1,100 @@
+package net.xolt.freecam.config;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.util.InputUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_F4;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_UNKNOWN;
+
+public enum ModBindings {
+
+    KEY_TOGGLE("toggle", GLFW_KEY_F4),
+    KEY_PLAYER_CONTROL("playerControl"),
+    KEY_TRIPOD_RESET("tripodReset"),
+    KEY_CONFIG_GUI("configGui");
+
+    private final Supplier<KeyBinding> lazyBinding;
+
+    ModBindings(String translationKey) {
+        this(translationKey, InputUtil.Type.KEYSYM, GLFW_KEY_UNKNOWN);
+    }
+
+    ModBindings(String translationKey, int code) {
+        this(translationKey, InputUtil.Type.KEYSYM, code);
+    }
+
+    ModBindings(String translationKey, InputUtil.Type type) {
+        this(translationKey, type, GLFW_KEY_UNKNOWN);
+    }
+
+    ModBindings(String translationKey, InputUtil.Type type, int code) {
+        this.lazyBinding = Suppliers.memoize(() ->
+                new KeyBinding("key.freecam." + translationKey, type, code, "category.freecam.freecam"));
+    }
+
+    /**
+     * @return the result of calling {@link KeyBinding#isPressed()} on the represented {@link KeyBinding}.
+     * @see KeyBinding#isPressed()
+     */
+    public boolean isPressed() {
+        return get().isPressed();
+    }
+
+    /**
+     * @return the result of calling {@link KeyBinding#wasPressed()} on the represented {@link KeyBinding}.
+     * @see KeyBinding#wasPressed()
+     */
+    public boolean wasPressed() {
+        return get().wasPressed();
+    }
+
+    /**
+     * Lazily get the actual {@link KeyBinding} represented by this enum value.
+     * <p>
+     * Values are constructed if they haven't been already.
+     *
+     * @return the actual {@link KeyBinding}.
+     */
+    public KeyBinding get() {
+        return lazyBinding.get();
+    }
+
+    /**
+     * Calls {@code action} using each {@link KeyBinding} owned by this enum.
+     * <p>
+     * Values are constructed if they haven't been already.
+     * <p>
+     * Static implementation of {@link Iterable#forEach(Consumer)}.
+     */
+    public static void forEach(@NotNull Consumer<KeyBinding> action) {
+        Objects.requireNonNull(action);
+        iterator().forEachRemaining(action);
+    }
+
+    /**
+     * Static implementation of {@link Iterable#iterator()}.
+     */
+    public static @NotNull Iterator<KeyBinding> iterator() {
+        return Arrays.stream(values())
+                .map(ModBindings::get)
+                .iterator();
+    }
+
+    /**
+     * Static implementation of {@link Iterable#spliterator()}.
+     */
+    public static @NotNull Spliterator<KeyBinding> spliterator() {
+        return Arrays.stream(values())
+                .map(ModBindings::get)
+                .spliterator();
+    }
+}

--- a/common/src/main/java/net/xolt/freecam/mixins/ClientConnectionMixin.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/ClientConnectionMixin.java
@@ -13,9 +13,6 @@ public class ClientConnectionMixin {
     // Disables freecam if the player disconnects.
     @Inject(method = "handleDisconnection", at = @At("HEAD"))
     private void onHandleDisconnection(CallbackInfo ci) {
-        if (Freecam.isEnabled()) {
-            Freecam.toggle();
-        }
-        Freecam.clearTripods();
+        Freecam.onDisconnect();
     }
 }

--- a/common/src/main/java/net/xolt/freecam/mixins/MinecraftClientMixin.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/MinecraftClientMixin.java
@@ -1,8 +1,6 @@
 package net.xolt.freecam.mixins;
 
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.input.Input;
-import net.minecraft.client.input.KeyboardInput;
 import net.xolt.freecam.Freecam;
 import net.xolt.freecam.config.ModConfig;
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,28 +9,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static net.xolt.freecam.Freecam.MC;
-
 @Mixin(MinecraftClient.class)
 public class MinecraftClientMixin {
-
-    // Prevents player from being controlled when freecam is enabled.
-    @Inject(method = "tick", at = @At("HEAD"))
-    private void onTick(CallbackInfo ci) {
-        if (Freecam.isEnabled()) {
-            if (MC.player != null && MC.player.input instanceof KeyboardInput && !Freecam.isPlayerControlEnabled()) {
-                Input input = new Input();
-                input.sneaking = MC.player.input.sneaking; // Makes player continue to sneak after freecam is enabled.
-                MC.player.input = input;
-            }
-            MC.gameRenderer.setRenderHand(ModConfig.INSTANCE.visual.showHand);
-
-            if (Freecam.disableNextTick()) {
-                Freecam.toggle();
-                Freecam.setDisableNextTick(false);
-            }
-        }
-    }
 
     // Prevents attacks when allowInteract is disabled.
     @Inject(method = "doAttack", at = @At("HEAD"), cancellable = true)

--- a/common/src/main/java/net/xolt/freecam/mixins/MinecraftClientMixin.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/MinecraftClientMixin.java
@@ -9,6 +9,9 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static net.xolt.freecam.config.ModBindings.KEY_TOGGLE;
+import static net.xolt.freecam.config.ModBindings.KEY_TRIPOD_RESET;
+
 @Mixin(MinecraftClient.class)
 public class MinecraftClientMixin {
 
@@ -39,7 +42,7 @@ public class MinecraftClientMixin {
     // Prevents hotbar keys from changing selected slot when freecam key is held
     @Inject(method = "handleInputEvents", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/KeyBinding;wasPressed()Z", ordinal = 2), cancellable = true)
     private void onHandleInputEvents(CallbackInfo ci) {
-        if (Freecam.KEY_TOGGLE.isPressed() || Freecam.KEY_TRIPOD_RESET.isPressed()) {
+        if (KEY_TOGGLE.isPressed() || KEY_TRIPOD_RESET.isPressed()) {
             ci.cancel();
         }
     }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -23,9 +23,6 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
     modApi "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_api_version}"
 
-    modApi "dev.architectury:architectury-fabric:${rootProject.architectury_version}"
-    include "dev.architectury:architectury-fabric:${rootProject.architectury_version}"
-
     modImplementation ("com.terraformersmc:modmenu:${rootProject.modmenu_version}") {
         exclude module: "fabric-api"
     }

--- a/fabric/src/main/java/net/xolt/freecam/fabric/FreecamFabric.java
+++ b/fabric/src/main/java/net/xolt/freecam/fabric/FreecamFabric.java
@@ -4,13 +4,14 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.xolt.freecam.Freecam;
+import net.xolt.freecam.config.ModBindings;
 import net.xolt.freecam.config.ModConfig;
 
 public class FreecamFabric implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
         ModConfig.init();
-        Freecam.ALL_KEYS.forEach(KeyBindingHelper::registerKeyBinding);
+        ModBindings.forEach(KeyBindingHelper::registerKeyBinding);
         ClientTickEvents.START_CLIENT_TICK.register(Freecam::preTick);
         ClientTickEvents.END_CLIENT_TICK.register(Freecam::postTick);
     }

--- a/fabric/src/main/java/net/xolt/freecam/fabric/FreecamFabric.java
+++ b/fabric/src/main/java/net/xolt/freecam/fabric/FreecamFabric.java
@@ -1,11 +1,17 @@
 package net.xolt.freecam.fabric;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.xolt.freecam.Freecam;
+import net.xolt.freecam.config.ModConfig;
 
 public class FreecamFabric implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
-        Freecam.init();
+        ModConfig.init();
+        Freecam.ALL_KEYS.forEach(KeyBindingHelper::registerKeyBinding);
+        ClientTickEvents.START_CLIENT_TICK.register(Freecam::preTick);
+        ClientTickEvents.END_CLIENT_TICK.register(Freecam::postTick);
     }
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -30,9 +30,6 @@ configurations {
 dependencies {
     forge "net.minecraftforge:forge:${rootProject.forge_version}"
 
-    modApi "dev.architectury:architectury-forge:${rootProject.architectury_version}"
-    include "dev.architectury:architectury-forge:${rootProject.architectury_version}"
-
     modApi "me.shedaniel.cloth:cloth-config-forge:${rootProject.cloth_version}"
     include "me.shedaniel.cloth:cloth-config-forge:${rootProject.cloth_version}"
 

--- a/forge/src/main/java/net/xolt.freecam/forge/FreecamForge.java
+++ b/forge/src/main/java/net/xolt.freecam/forge/FreecamForge.java
@@ -13,6 +13,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.xolt.freecam.Freecam;
+import net.xolt.freecam.config.ModBindings;
 import net.xolt.freecam.config.ModConfig;
 
 @Mod(Freecam.MOD_ID)
@@ -31,7 +32,7 @@ public class FreecamForge {
 
     @SubscribeEvent
     public static void registerKeymappings(RegisterKeyMappingsEvent event) {
-        Freecam.ALL_KEYS.forEach(event::register);
+        ModBindings.forEach(event::register);
     }
 
     @Mod.EventBusSubscriber(bus = Bus.FORGE, value = Dist.CLIENT)

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,8 +9,6 @@ archives_base_name=freecam
 mod_version=1.2.1.1
 maven_group=net.xolt.freecam
 
-architectury_version=10.0.16
-
 fabric_loader_version=0.14.25
 fabric_api_version=0.91.1+1.20.2
 


### PR DESCRIPTION
## Motivation

Fewer dependencies tied to minecraft versions/platforms makes it easier to support new/different mc versions without relying on others to do so first.

Although this means we have to manually use the various platform APIs we target, this isn't actually a big deal in our case, since we use very few APIs:
- Tick events
- Init event
- Keybind registration

Using the APIs directly may also give us more control.

## Implementation

- Cherry-picked the event handler refactoring from #126 
- Removed the Architectury API dependency from gradle config
- Implemented Fabric API calls
- Implemented Forge event handlers
- Refactored the mod's keybinding declaration (see below)

## Key bindings

Previously, keybinds were stored as discrete fields on the main `Freecam` class. This meant having to construct a separate `List` (or stream) in order to iterate over them when registering.

Rather than maintain a list of keybinds twice, which would be tedious and prone to error, I've introduced the `ModBindings` enum in the `config` package.

This has several advantages:
- We automatically get a list of all our key binds via `Enum::values`
- We can make declarations more readable using a custom constructor
- We can (more easily) construct the keybinds lazily, ensuring they aren't added to `KeyBinding`'s maps until we're ready to register them.

To minimize boilerplate elsewhere I've wrapped the `isPressed()` and `wasPressed()` methods. We could also introduce our own `wasPressedReset()` to improve handler code, e.g:

```java
public boolean wasPressedReset() {
    if (wasPressed()) {
        // Alternatively, use AW to access KeyBinding::reset
        // get().reset();
        while (wasPressed()) {}
        return true;
    }
    return false;
}
```