### PR TITLE
1.16.5: Compile for Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ allprojects {
     // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
     tasks.withType(JavaCompile) {
         options.encoding = "UTF-8"
-        options.release = 17
+        options.release = 8
     }
 
     java {

--- a/common/src/main/java/net/xolt/freecam/config/ConfigExtensions.java
+++ b/common/src/main/java/net/xolt/freecam/config/ConfigExtensions.java
@@ -66,7 +66,7 @@ public class ConfigExtensions {
     @Contract(mutates = "param1")
     private static void applyVariantTooltip(List<AbstractConfigListEntry> guis, List<VariantTooltip> tooltipVariants, String i18n) {
         String variant = BuildVariant.getInstance().name();
-        List<String> variants = List.of(variant, "all");
+        List<String> variants = Arrays.asList(variant, "all");
 
         // Number of tooltip lines defined for the current build variant (or "all")
         // (throw if there isn't exactly one matching definition)
@@ -74,9 +74,9 @@ public class ConfigExtensions {
                 .filter(entry -> variants.contains(entry.variant()))
                 .mapToInt(VariantTooltip::count)
                 .reduce((prev, next) -> {
-                    throw new IllegalArgumentException("%s: Multiple variants matching \"%s\" declared on \"%s\".".formatted(VariantTooltip.class.getSimpleName(), variant, i18n));
+                    throw new IllegalArgumentException(String.format("%s: Multiple variants matching \"%s\" declared on \"%s\".", VariantTooltip.class.getSimpleName(), variant, i18n));
                 })
-                .orElseThrow(() -> new IllegalStateException("%s: No variants matching \"%s\" declared on \"%s\".".formatted(VariantTooltip.class.getSimpleName(), variant, i18n)));
+                .orElseThrow(() -> new IllegalStateException(String.format("%s: No variants matching \"%s\" declared on \"%s\".", VariantTooltip.class.getSimpleName(), variant, i18n)));
 
         // Add tooltip to each of the fields guis that support tooltips
         // (except text entries)
@@ -125,9 +125,9 @@ public class ConfigExtensions {
      * @see #getVariantTooltip(String, String, int)
      */
     private static Component getVariantTooltipLine(String variant, String i18n, int index) {
-        String key = "%s.@%sTooltip".formatted(i18n, StringUtils.capitalize(variant));
+        String key = String.format("%s.@%sTooltip", i18n, StringUtils.capitalize(variant));
         if (index > -1) {
-            key += "[%d]".formatted(index);
+            key += String.format("[%d]", index);
         }
         // FIXME how will this behave for untranslated languages?
         if (Language.getInstance().has(key)) {

--- a/common/src/main/java/net/xolt/freecam/mixins/BlockStateBaseMixin.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/BlockStateBaseMixin.java
@@ -27,9 +27,10 @@ public abstract class BlockStateBaseMixin {
 
     @Inject(method = "getCollisionShape(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/phys/shapes/CollisionContext;)Lnet/minecraft/world/phys/shapes/VoxelShape;", at = @At("HEAD"), cancellable = true)
     private void onGetCollisionShape(BlockGetter world, BlockPos pos, CollisionContext context, CallbackInfoReturnable<VoxelShape> cir) {
-        if (context instanceof EntityCollisionContext entityShapeContext
-                && ((EntityCollisionContextMixinInterface)entityShapeContext).getEntity().isPresent()
-                && ((EntityCollisionContextMixinInterface)entityShapeContext).getEntity().get() instanceof FreeCamera) {
+        if (context instanceof EntityCollisionContext
+                && ((EntityCollisionContextMixinInterface) context).getEntity().isPresent()
+                && ((EntityCollisionContextMixinInterface) context).getEntity().get() instanceof FreeCamera) {
+            EntityCollisionContext entityShapeContext = (EntityCollisionContext) context;
             // Return early if "Always Check Initial Collision" is on and Freecam isn't enabled yet
             if (ModConfig.INSTANCE.collision.alwaysCheck && !Freecam.isEnabled()) {
                 return;

--- a/forge/src/main/java/net/xolt/freecam/forge/FreecamForge.java
+++ b/forge/src/main/java/net/xolt/freecam/forge/FreecamForge.java
@@ -3,12 +3,12 @@ package net.xolt.freecam.forge;
 import me.shedaniel.autoconfig.AutoConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.fml.ExtensionPoint;
-import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
@@ -39,8 +39,8 @@ public class FreecamForge {
         public static void onTick(TickEvent.ClientTickEvent event) {
             final Minecraft client = Minecraft.getInstance();
             switch (event.phase) {
-                case START -> Freecam.preTick(client);
-                case END -> Freecam.postTick(client);
+                case START: Freecam.preTick(client); break;
+                case END: Freecam.postTick(client); break;
             }
         }
     }

--- a/variant/api/src/main/java/net/xolt/freecam/variant/api/SingleInstanceServiceLoader.java
+++ b/variant/api/src/main/java/net/xolt/freecam/variant/api/SingleInstanceServiceLoader.java
@@ -1,9 +1,6 @@
 package net.xolt.freecam.variant.api;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
+import java.util.*;
 
 class SingleInstanceServiceLoader {
 
@@ -11,26 +8,27 @@ class SingleInstanceServiceLoader {
 
     static <T> T get(Class<T> type) {
         return type.cast(SERVICE_PROVIDERS.computeIfAbsent(type, key -> {
-            List<ServiceLoader.Provider<T>> providers = ServiceLoader.load(type).stream().toList();
+            T value = null;
+            List<String> names = new ArrayList<>();
 
-            if (providers.isEmpty()) {
-                String message = "Could not find any service providers for %s".formatted(type.getSimpleName());
+            for (T service : ServiceLoader.load(type)) {
+                value = service;
+                names.add(service.getClass().getSimpleName());
+            }
+
+            if (value == null) {
+                String message = String.format("Could not find any service providers for %s", type.getSimpleName());
                 System.out.println(message);
                 throw new IllegalStateException(message);
             }
 
-            if (providers.size() > 1) {
-                String message = "Found multiple service providers for %s%n%s".formatted(type.getSimpleName(),
-                        providers.stream()
-                                .map(provider -> provider.type().getSimpleName())
-                                .map(s -> " - " + s)
-                                .toList()
-                                .toString());
+            if (names.size() > 1) {
+                String message = String.format("Found multiple service providers for %s%n%s", type.getSimpleName(), names);
                 System.out.println(message);
                 throw new IllegalStateException(message);
             }
 
-            return providers.get(0).get();
+            return value;
         }));
     }
 


### PR DESCRIPTION
This fixes class version errors when attempting to launch the prod build.

There are still other errors this doesn't fix yet:

- [ ] Cloth Config is missing in production (i.e. JarJar isn't working)
- [ ] Dev-Env runs are broken (complaining about `'com.mojang.math.Transformation com.mojang.math.Transformation.func_227987_b_()'`).

The first issue should be fix-able using shadow.  EDIT: this will be a bit of a pain, because loom won't convert our AW to AT if cloth-config's AT is already in the jar... We could _really_ hack-fix that by including cloth's transforms in our AW and excluding their AT in the `shadowJar` task...

The second issue could be an arch-loom bug affecting older MC versions?

Incidentally, Java8's version of `SingleInstanceServiceLoader` _might_ be nicer than the version I originally wrote using streams? :thinking: 