### PR TITLE
Store whitelist conditions as predicate functions

### DIFF
--- a/common/src/main/java/net/xolt/freecam/config/CollisionWhitelist.java
+++ b/common/src/main/java/net/xolt/freecam/config/CollisionWhitelist.java
@@ -1,36 +1,73 @@
 package net.xolt.freecam.config;
 
-import net.minecraft.world.level.block.BarrierBlock;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.DoorBlock;
-import net.minecraft.world.level.block.FenceGateBlock;
-import net.minecraft.world.level.block.IronBarsBlock;
-import net.minecraft.world.level.block.TransparentBlock;
-import net.minecraft.world.level.block.TrapDoorBlock;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.level.block.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class CollisionWhitelist {
 
-    private static final Collection<Class<? extends Block>> transparentWhitelist = List.of(
-            TransparentBlock.class,
-            IronBarsBlock.class,
-            BarrierBlock.class);
+    private static final Predicate<Block> transparent = Builder.builder()
+            .matching(TransparentBlock.class, IronBarsBlock.class)
+            .matching(BarrierBlock.class)
+            .build();
 
-    private static final Collection<Class<? extends Block>> openableWhitelist = List.of(
-            FenceGateBlock.class,
-            DoorBlock.class,
-            TrapDoorBlock.class);
+    private static final Predicate<Block> openable = Builder.builder()
+            .matching(FenceGateBlock.class)
+            .matching(DoorBlock.class, TrapDoorBlock.class)
+            .build();
 
     public static boolean isTransparent(Block block) {
-        return isMatch(block, transparentWhitelist);
+        return transparent.test(block);
     }
 
     public static boolean isOpenable(Block block) {
-        return isMatch(block, openableWhitelist);
+        return openable.test(block);
     }
 
-    private static boolean isMatch(Block block, Collection<Class<? extends Block>> whitelist) {
-        return whitelist.stream().anyMatch(blockClass -> blockClass.isInstance(block));
+    private static String getBlockId(Block block) {
+        return BuiltInRegistries.BLOCK.getKey(block).toString();
+    }
+
+    private static class Builder {
+        private final Collection<Predicate<Block>> predicates = new ArrayList<>();
+
+        private Builder() {}
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public final Builder matching(String... ids) {
+            return matching(block -> Arrays.asList(ids).contains(getBlockId(block)));
+        }
+
+        public final Builder matching(Pattern... patterns) {
+            return matching(block -> {
+                String id = getBlockId(block);
+                return Arrays.stream(patterns)
+                        .map(pattern -> pattern.matcher(id))
+                        .anyMatch(Matcher::find);
+            });
+        }
+
+        @SafeVarargs
+        public final Builder matching(Class<? extends Block>... classes) {
+            return matching(block -> Arrays.stream(classes).anyMatch(clazz -> clazz.isInstance(block)));
+        }
+
+        public final Builder matching(Predicate<Block> predicate) {
+            predicates.add(predicate);
+            return this;
+        }
+
+        public Predicate<Block> build() {
+            return block -> predicates.stream().anyMatch(predicate -> predicate.test(block));
+        }
     }
 }


### PR DESCRIPTION
This small refactor enables the collision whitelist to be more flexible.

The predicate builder now supports:  
- Matching on block class (existing behavior).
- Matching on block ID string.
- Regex matching on block ID string.
- Matching using an arbitrary predicate function.

This PR could be expanded or followed up with:  
- More explicit whitelists using block ID matching.
- User-configurable whitelists/blacklists edited vla a cloth-config.
  - Autoconfig creates a [`StringListListEntry`](https://github.com/shedaniel/cloth-config/blob/461ae8e56fa02f0422e2b8a3b1f38d743e5fba7e/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/StringListListEntry.java#L35) for `List<String>` and `String[]` config fields.
  - I've [played around a little](https://github.com/MattSturgeon/Freecam/blob/d83662bd33f4d3a5a685fc54b92199b1923654d4/common/src/main/java/net/xolt/freecam/config/gui/ValidateRegexImpl.java#L37) with adding an "error supplier" to validate whitelist regex patterns.