### PR TITLE
Add Parchment mappings layer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,22 @@ subprojects {
     }
 
     dependencies {
+        def parchmentAppendix
+        def parchmentVersion
+        def parts = rootProject.parchment_version.split('-')
+        if (parts.size() == 2) {
+            parchmentAppendix = parts[0]
+            parchmentVersion = parts[1]
+        } else {
+            parchmentAppendix = rootProject.minecraft_version
+            parchmentVersion = parts[0]
+        }
+
         minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
-        mappings loom.officialMojangMappings()
+        mappings loom.layered() {
+            officialMojangMappings()
+            parchment("org.parchmentmc.data:parchment-${parchmentAppendix}:${parchmentVersion}@zip")
+        }
 //        modLocalRuntime "com.ptsmods:devlogin:${rootProject.devlogin_version}"
     }
 }
@@ -75,6 +89,7 @@ allprojects {
         // See https://docs.gradle.org/current/userguide/declaring_repositories.html
         // for more information about repositories.
         mavenCentral()
+        maven { url "https://maven.parchmentmc.org/" }
         maven { url "https://maven.neoforged.net/releases/" }
         maven { url "https://maven.shedaniel.me/" }
         maven { url "https://maven.terraformersmc.com/" }

--- a/build.gradle
+++ b/build.gradle
@@ -47,16 +47,8 @@ subprojects {
     }
 
     dependencies {
-        def parchmentAppendix
-        def parchmentVersion
-        def parts = rootProject.parchment_version.split('-')
-        if (parts.size() == 2) {
-            parchmentAppendix = parts[0]
-            parchmentVersion = parts[1]
-        } else {
-            parchmentAppendix = rootProject.minecraft_version
-            parchmentVersion = parts[0]
-        }
+        def parchmentAppendix = rootProject.parchment_version.split('-')[0]
+        def parchmentVersion = rootProject.parchment_version.split('-')[1]
 
         minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
         mappings loom.layered() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,9 +17,11 @@ build_variants=normal,modrinth
 # https://discord.architectury.dev
 # https://modmuss50.me/fabric.html
 # https://projects.neoforged.net/neoforged/neoforge
+# https://maven.parchmentmc.org/org/parchmentmc/data
 # Forge dependencies use maven's version range spec:
 # https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
 minecraft_version=1.20.4
+parchment_version=1.20.2-2023.12.10
 
 fabric_loader_version=0.15.3
 fabric_api_version=0.91.2+1.20.4


### PR DESCRIPTION
This PR adds parchment mappings.

Mojang's mappings cover **class**, **method**, & **field** names. Parchment builds on this by providing mappings for **parameter** names and some **javadocs**, though not nearly as much javadoc as yarn currently has.

I slightly over-complicated things by making the parchment _minecraft_ version optional:

- If `parchment_version` contains a hyphen, the first part is the minecraft version, appended to the artifact name.
- If there's no hyphen, then the project `minecraft_version` is used instead.

This means when parchment has a release exactly matching the minecraft version we're using, we don't need to specify it twice.

For example, we are using 1.20.4, however Parchment has a stable build for 1.20.2 and unstable builds for 1.20.3. Therefore we currently need to specify two different mc versions.

If you don't think the complexity is worth it, I can remove the complexity and we'll always specify parchment's mc version explicitly.

We may also want to be able to _disable_ parchment. We could do this by adding a check for `project.parchment_version == "off"` (or similar). Or we could comment the parchment line on an ad-hoc basis.